### PR TITLE
Fix Wildtrack evaluation

### DIFF
--- a/src/utils/tools.py
+++ b/src/utils/tools.py
@@ -1,4 +1,5 @@
 import os
+import numpy as np
 import motmetrics as mm
 from loguru import logger
 
@@ -28,3 +29,30 @@ def evaluate(cfg, output_dir):
         accs.append(mm.utils.compare_to_groundtruth(gt, ts, 'iou', distth=0.5))
     summary = mh.compute_many(accs, metrics=metrics, generate_overall=True)#, name=names)
     logger.info(f'\n{mm.io.render_summary(summary, formatters=mh.formatters, namemap=mm.io.motchallenge_metric_names)}')
+
+    if cfg.DATASET.NAME == 'Wildtrack':
+        mh = mm.metrics.create()
+
+        print('=========== Wildtrack GROUND PLANE evaluation ===========')
+        gt_file = f'{cfg.DATASET.DIR}{cfg.DATASET.NAME}/{cfg.DATASET.SEQUENCE[0]}/output/gt_MOT/gp.txt'
+        ts_file = os.path.join(output_dir, f'gp.txt')
+
+        gt = np.loadtxt(gt_file, delimiter=',')
+        t = np.loadtxt(ts_file, delimiter=',')
+
+        acc = mm.MOTAccumulator(auto_id=True)
+        for frame in np.unique(gt[:, 0]).astype(int):
+            gt_dets = gt[gt[:, 0] == frame][:, (1, 6, 7)]
+            t_dets = t[t[:, 0] == frame][:, (1, 7, 8)]
+
+            # world grid to world coord in meters
+            t_trans = (t_dets[:, 1:3] / 2.5) + np.array([360, 120])
+
+            C = mm.distances.norm2squared_matrix(gt_dets[:, 1:3]  * 0.025, t_trans * 0.025, max_d2=1)
+            C = np.sqrt(C)
+
+            acc.update(gt_dets[:, 0].astype('int').tolist(), t_dets[:, 0].astype('int').tolist(), C)
+
+        summary = mh.compute(acc, metrics=metrics)
+        logger.info(
+            f'\n{mm.io.render_summary(summary, formatters=mh.formatters, namemap=mm.io.motchallenge_metric_names)}')

--- a/src/utils/tracklet.py
+++ b/src/utils/tracklet.py
@@ -366,6 +366,7 @@ class Tracklet():
 
         g_fID = self.graph.ndata['fID']
         g_tID = self.graph.ndata['tID_pred']
+        g_proj = self.graph.ndata['proj']
 
         dfs = []
         for _ in range(self.cfg.DATASET.CAMS):
@@ -398,6 +399,30 @@ class Tracklet():
                           sep=',',
                           mode='a')
 
+        gp_dfs = pd.DataFrame(columns=attr)
+        for n in range(self.graph.num_nodes()):
+            if g_fID[n] != current_fID:  # online method, only preprocess current nodes
+                continue
+            y, x, _ = g_proj[n].cpu().tolist()
+            gp_dfs = gp_dfs.append(
+                {
+                    'frame': frame,
+                    'id': g_tID[n].cpu().item(),
+                    'bb_left': -1,
+                    'bb_top': -1,
+                    'bb_width': -1,
+                    'bb_height': -1,
+                    'conf': 1,
+                    'x': x,
+                    'y': y,
+                    'z': -1
+                },
+                ignore_index=True)
+        gp_dfs.to_csv(os.path.join(self.outpu_dir, f'gp.txt'),
+                      header=None,
+                      index=None,
+                      sep=',',
+                      mode='a')
     def aggregating_tg(self):
         nxg = dgl.to_networkx(self.graph.cpu()).to_undirected()
 


### PR DESCRIPTION
Hi guys,

I like your work on Multi-View Tracking, but I was confused about your results on Wildtrack.
Your code showed that you evaluate tracking over all views, but Wildtrack is evaluated in the projected view / bird's eye view.

I added the groundtruth creation and the evaluation to your repo. You also didn't include the first frame of the test set in your evaluation. Currently your codebase doesn't give results for the first frame on inference.

I re-ran the evaluation (with ground truth image detection) and I got the following results:

| Method | IDF1 | IDP | IDR | MT | ML | FP | FN | IDs | FM | MOTA | MOTP |
| ---- | --- | --- | ---- | ---- | --- | --- | --- | --- | --- | --- | --- | 
| T-Glimpse | 77.8 | 79.3 | 76.4 | 61 | 4.9 | 91 | 126 | 42 | 43 | 72.8 | 79.1 |
| T-Glimpse Stack  | 81.9 | 81.6 | 82.2 | 65.9 | 4.9 | 114 | 107 | 21 | 34 | 74.6 | 78.9 |
| ReST **(\w GT BBoxes)** | 76.6 | 74.9 | 78.4 | 35 | 0 | 97 | 56 | 40 | 19 | 77.5 | 99.9 |
| ReST **(\w MVDeTr dets)** | |

Unfortunately you didn't provide `'./datasets/Wildtrack/sequence1/output/MVDeTr_test.json'`. Could you upload it so I can re-run the results for fair comparison?

Best,
Torben